### PR TITLE
Fix io disconnect

### DIFF
--- a/.github/workflows/pr-validator.yml
+++ b/.github/workflows/pr-validator.yml
@@ -10,11 +10,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-
+      - uses: actions/checkout@v4.1.1
+      - uses: hecrj/setup-rust-action@v2.0.0
       - name: Format check
         run: cargo fmt  -- --check
       - name: Build and Lint

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -61,9 +61,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "futures"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da0290714b38af9b4a7b094b8a37086d1b4e61f2df9122c3cad2577669145335"
+checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -76,9 +76,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff4dd66668b557604244583e3e1e1eada8c5c2e96a6d0d6653ede395b78bbacb"
+checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -86,15 +86,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb1d22c66e66d9d72e1758f0bd7d4fd0bee04cad842ee34587d68c07e45d088c"
+checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f4fb8693db0cf099eadcca0efe2a5a22e4550f98ed16aba6c48700da29597bc"
+checksum = "a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -103,15 +103,15 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bf34a163b5c4c52d0478a4d757da8fb65cabef42ba90515efee0f6f9fa45aaa"
+checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53b153fd91e4b0147f4aced87be237c98248656bb01050b96bf3ee89220a8ddb"
+checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -120,21 +120,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e36d3378ee38c2a36ad710c5d30c2911d752cb941c00c72dbabfb786a7970817"
+checksum = "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5"
 
 [[package]]
 name = "futures-task"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efd193069b0ddadc69c46389b740bbccdd97203899b48d09c5f7969591d6bae2"
+checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
 
 [[package]]
 name = "futures-util"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a19526d624e703a3179b3d322efec918b6246ea0fa51d41124525f00f1cc8104"
+checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -292,7 +292,7 @@ checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
 name = "sdre-stubborn-io"
-version = "0.4.4"
+version = "0.5.0"
 dependencies = [
  "futures",
  "log",
@@ -333,9 +333,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.34.0"
+version = "1.35.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0c014766411e834f7af5b8f4cf46257aab4036ca95e9d2c144a10f59ad6f5b9"
+checksum = "c89b4efa943be685f629b149f53829423f8f5531ea21249408e8e2f8671ec104"
 dependencies = [
  "backtrace",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sdre-stubborn-io"
-version = "0.4.4"
+version = "0.5.0"
 authors = ["David Raifaizen <david.raifaizen@protonmail.com>", "Fred Clausen"]
 edition = "2021"
 description = "Forked from https://github.com/craftytrickster/stubborn-io. io traits/structs that automatically recover from potential disconnections/interruptions."
@@ -11,11 +11,11 @@ documentation = "https://docs.rs/sdre-stubborn-io"
 readme = "README.md"
 
 [dependencies]
-tokio = { version = "1.34.0", features = ["time", "net"] }
+tokio = { version = "1.35.1", features = ["time", "net"] }
 log = "0.4.20"
 rand = "0.8.5"
 
 [dev-dependencies]
-tokio = { version = "1.34.0", features = ["macros", "rt", "fs", "io-util"] }
+tokio = { version = "1.35.1", features = ["macros", "rt", "fs", "io-util"] }
 tokio-util = { version = "0.7.10", features = ["codec"] }
-futures = "0.3.29"
+futures = "0.3.30"

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This project has been forked from [stubborn-io](https://github.com/craftytrickst
 ## Documentation
 
 API Documentation, examples and motivations can be found here -
-(Rust Docs)<https://docs.rs/stubborn-io> .
+(Rust Docs)<https://docs.rs/sdre-stubborn-io> .
 
 Only change to the documentation in this fork will be the addition of the `ReconnectionOptions` struct, which adds `with_connection_name(name: &str)` as a method to the `StubbornTcpStream` struct. This allows for the naming of the connection, which is useful for logging purposes.
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -26,6 +26,10 @@ pub struct ReconnectOptions {
     pub on_connect_fail_callback: Box<dyn Fn() + Send + Sync>,
 
     pub connection_name: String,
+
+    /// If this is set to false (default), then the StubbornIo will NOT block
+    /// On write failures.
+    pub block_on_write_failures: bool,
 }
 
 impl ReconnectOptions {
@@ -41,6 +45,7 @@ impl ReconnectOptions {
             on_disconnect_callback: Box::new(|| {}),
             on_connect_fail_callback: Box::new(|| {}),
             connection_name: String::new(),
+            block_on_write_failures: false,
         }
     }
 
@@ -95,6 +100,11 @@ impl ReconnectOptions {
 
     pub fn with_connection_name(mut self, name: impl Into<String>) -> Self {
         self.connection_name = name.into();
+        self
+    }
+
+    pub fn with_block_on_write_failures(mut self, value: bool) -> Self {
+        self.block_on_write_failures = value;
         self
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -55,7 +55,7 @@ impl ReconnectOptions {
     ///
     /// ```
     /// use std::time::Duration;
-    /// use stubborn_io::ReconnectOptions;
+    /// use sdre_stubborn_io::ReconnectOptions;
     ///
     /// // With the below vector, the stubborn-io item will try to reconnect three times,
     /// // waiting 2 seconds between each attempt. Once all three tries are exhausted,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@
 //! use std::future::Future;
 //! use std::path::PathBuf;
 //! use std::pin::Pin;
-//! use stubborn_io::tokio::{StubbornIo, UnderlyingIo};
+//! use sdre_stubborn_io::tokio::{StubbornIo, UnderlyingIo};
 //! use tokio::fs::File;
 //!
 //! struct MyFile(File); // Struct must implement AsyncRead + AsyncWrite

--- a/src/strategies.rs
+++ b/src/strategies.rs
@@ -7,7 +7,7 @@ use std::time::Duration;
 ///
 /// ```
 /// use std::time::Duration;
-/// use stubborn_io::{ReconnectOptions, strategies::ExpBackoffStrategy};
+/// use sdre_stubborn_io::{ReconnectOptions, strategies::ExpBackoffStrategy};
 ///
 /// // With the below strategy, the stubborn-io item will try to reconnect infinitely,
 /// // waiting an exponentially increasing (by 2) value with 5% random jitter. Once the

--- a/src/tokio/io.rs
+++ b/src/tokio/io.rs
@@ -1,5 +1,5 @@
 use crate::config::ReconnectOptions;
-use log::{error, info};
+use log::{error, info, warn};
 use std::future::Future;
 use std::io::{self, ErrorKind, IoSlice};
 use std::marker::PhantomData;
@@ -95,12 +95,24 @@ enum Status<T, C> {
     FailedAndExhausted, // the way one feels after programming in dynamically typed languages
 }
 
+#[inline]
+fn poll_err<T>(
+    kind: ErrorKind,
+    reason: impl Into<Box<dyn std::error::Error + Send + Sync>>,
+) -> Poll<io::Result<T>> {
+    let io_err = io::Error::new(kind, reason);
+    Poll::Ready(Err(io_err))
+}
+
 fn exhausted_err<T>() -> Poll<io::Result<T>> {
-    let io_err = io::Error::new(
+    poll_err(
         ErrorKind::NotConnected,
         "Disconnected. Connection attempts have been exhausted.",
-    );
-    Poll::Ready(Err(io_err))
+    )
+}
+
+fn disconnected_err<T>() -> Poll<io::Result<T>> {
+    poll_err(ErrorKind::NotConnected, "Underlying I/O is disconnected.")
 }
 
 impl<T, C> Deref for StubbornIo<T, C> {
@@ -145,6 +157,10 @@ where
 
     pub fn get_connection_name(&self) -> String {
         self.options.connection_name.format_name()
+    }
+
+    pub fn get_block_on_write_failures(&self) -> bool {
+        self.options.block_on_write_failures.clone()
     }
 
     pub async fn connect_with_options(ctor_arg: C, options: ReconnectOptions) -> io::Result<Self> {
@@ -380,8 +396,8 @@ where
     C: Clone + Send + Unpin + 'static,
 {
     /// Method for writing to the underlying IO item.
-    /// If the write results in a disconnect, the write is skipped and the
-    /// underlying IO item will attempt to be reconnected.
+    /// If the write results in a disconnect. If ReconectOptions::block_on_write_failures is true,
+    /// Poll::Pending is returned to the caller and the buffer is held. Otherwise, the write is skipped
     /// No error is returned to the caller.
     fn poll_write(
         mut self: Pin<&mut Self>,
@@ -393,23 +409,43 @@ where
                 let poll = AsyncWrite::poll_write(Pin::new(&mut self.underlying_io), cx, buf);
 
                 if self.is_write_disconnect_detected(&poll) {
-                    error!(
-                        "{}Write disconnect detected. Skipping message",
-                        &self.get_connection_name()
-                    );
-                    self.on_disconnect(cx);
-                    Poll::Ready(Ok(buf.len()))
+                    if !self.get_block_on_write_failures() {
+                        error!(
+                            "{}Write disconnect detected. Skipping message",
+                            &self.get_connection_name()
+                        );
+
+                        self.on_disconnect(cx);
+                        Poll::Ready(Ok(buf.len()))
+                    } else {
+                        warn!(
+                            "{}Write disconnect detected. Blocking on write",
+                            &self.get_connection_name()
+                        );
+                        self.on_disconnect(cx);
+                        Poll::Pending
+                    }
                 } else {
                     poll
                 }
             }
             Status::Disconnected(_) => {
-                error!(
-                    "{}Write disconnect detected. Skipping Message",
-                    &self.get_connection_name()
-                );
-                self.poll_disconnect(cx);
-                Poll::Ready(Ok(buf.len()))
+                if !self.get_block_on_write_failures() {
+                    error!(
+                        "{}Write disconnect detected. Skipping Message",
+                        &self.get_connection_name()
+                    );
+
+                    self.poll_disconnect(cx);
+                    Poll::Ready(Ok(buf.len()))
+                } else {
+                    warn!(
+                        "{}Write disconnect detected. Blocking on write",
+                        &self.get_connection_name()
+                    );
+                    self.poll_disconnect(cx);
+                    Poll::Pending
+                }
             }
             Status::FailedAndExhausted => exhausted_err(),
         }
@@ -446,14 +482,14 @@ where
 
                 poll
             }
-            Status::Disconnected(_) => Poll::Pending,
+            Status::Disconnected(_) => disconnected_err(),
             Status::FailedAndExhausted => exhausted_err(),
         }
     }
 
     /// Method for writing to the underlying IO item.
-    /// If the write results in a disconnect, the write is skipped and the
-    /// underlying IO item will attempt to be reconnected.
+    /// If the write results in a disconnect. If ReconectOptions::block_on_write_failures is true,
+    /// Poll::Pending is returned to the caller and the buffer is held. Otherwise, the write is skipped
     /// No error is returned to the caller.
     fn poll_write_vectored(
         mut self: Pin<&mut Self>,
@@ -466,23 +502,43 @@ where
                     AsyncWrite::poll_write_vectored(Pin::new(&mut self.underlying_io), cx, bufs);
 
                 if self.is_write_disconnect_detected(&poll) {
-                    error!(
-                        "{}Write disconnect detected. Skipping message",
-                        &self.get_connection_name()
-                    );
-                    self.on_disconnect(cx);
-                    Poll::Ready(Ok(bufs.iter().map(|buf| buf.len()).sum()))
+                    if !self.get_block_on_write_failures() {
+                        error!(
+                            "{}Write disconnect detected. Skipping message",
+                            &self.get_connection_name()
+                        );
+
+                        self.on_disconnect(cx);
+                        Poll::Ready(Ok(bufs.iter().map(|buf| buf.len()).sum()))
+                    } else {
+                        warn!(
+                            "{}Write disconnect detected. Blocking on write",
+                            &self.get_connection_name()
+                        );
+                        self.on_disconnect(cx);
+                        Poll::Pending
+                    }
                 } else {
                     poll
                 }
             }
             Status::Disconnected(_) => {
-                error!(
-                    "{}Write disconnect detected. Skipping Message",
-                    &self.get_connection_name()
-                );
-                self.poll_disconnect(cx);
-                Poll::Ready(Ok(bufs.iter().map(|buf| buf.len()).sum()))
+                if !self.get_block_on_write_failures() {
+                    error!(
+                        "{}Write disconnect detected. Skipping Message",
+                        &self.get_connection_name()
+                    );
+
+                    self.poll_disconnect(cx);
+                    Poll::Ready(Ok(bufs.iter().map(|buf| buf.len()).sum()))
+                } else {
+                    warn!(
+                        "{}Write disconnect detected. Blocking on write",
+                        &self.get_connection_name()
+                    );
+                    self.poll_disconnect(cx);
+                    Poll::Pending
+                }
             }
             Status::FailedAndExhausted => exhausted_err(),
         }

--- a/src/tokio/io.rs
+++ b/src/tokio/io.rs
@@ -160,7 +160,7 @@ where
     }
 
     pub fn get_block_on_write_failures(&self) -> bool {
-        self.options.block_on_write_failures.clone()
+        self.options.block_on_write_failures
     }
 
     pub async fn connect_with_options(ctor_arg: C, options: ReconnectOptions) -> io::Result<Self> {

--- a/src/tokio/tcp.rs
+++ b/src/tokio/tcp.rs
@@ -17,7 +17,7 @@ where
 /// distinction that it will automatically attempt to reconnect in the face of connectivity failures.
 ///
 /// ```
-/// use stubborn_io::StubbornTcpStream;
+/// use sdre_stubborn_io::StubbornTcpStream;
 /// use tokio::io::AsyncWriteExt;
 ///
 /// let addr = "localhost:8080";

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1,0 +1,28 @@
+use std::time::Duration;
+
+use stubborn_io::StubbornTcpStream;
+use tokio::{io::AsyncWriteExt, sync::oneshot};
+
+#[tokio::test]
+async fn back_to_back_shutdown_attempts() {
+    let (port_tx, port_rx) = oneshot::channel();
+    tokio::spawn(async move {
+        let mut streams = Vec::new();
+        let listener = tokio::net::TcpListener::bind("0.0.0.0:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        port_tx.send(addr).unwrap();
+        loop {
+            let (stream, _addr) = listener.accept().await.unwrap();
+            streams.push(stream);
+        }
+    });
+    let addr = port_rx.await.unwrap();
+    let mut connection = StubbornTcpStream::connect(addr).await.unwrap();
+
+    connection.shutdown().await.unwrap();
+    let elapsed = tokio::time::timeout(Duration::from_secs(5), connection.shutdown()).await;
+
+    let result = elapsed.unwrap();
+    let error = result.unwrap_err();
+    assert_eq!(error.kind(), std::io::ErrorKind::NotConnected);
+}

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1,6 +1,6 @@
 use std::time::Duration;
 
-use stubborn_io::StubbornTcpStream;
+use sdre_stubborn_io::StubbornTcpStream;
 use tokio::{io::AsyncWriteExt, sync::oneshot};
 
 #[tokio::test]


### PR DESCRIPTION
Updated the following:

* Dependencies
* Merged upstream with a minor fix that I'm not sure applies to our use case, but I figured it should be here
* Added an option to toggle block on write failure behavior. Default is NOT to block on write failure
* In the poll_write methods it now, based on the configured option for write blocking, will return a success case and just simply log the write failure

The logic behind the poll_write changes is that, for the use case we primarily use for this library we do NOT want to block endlessly while awaiting a write success. Basically, the idea is that we try a write and if it fails the message should be discarded, anyway.

Potential issues:

* I did not address the flush methods. I'm not sure if this is necessary or not. In my testing it appears to work as is
* There still appears to be a delay in detecting if the socket is actually disconnected which may add in a bit of a write delay in the caller if the socket has been disconnected, but it hasn't detected it yet. I believe it only tries to check socket status on writes, which I assume causes a delay that we have to await before it enters a failure condition. Whatever is going on the socket definitely does not tag as bad as early as it should. 

Future improvements?:

* It may be worth spinning up an async task to periodically check socket status. I'm not sure what that would look like, but if we check socket health outside of a write we could mark the socket as disconnected earlier then it appears it will