### PR TITLE
chore(flake/precommit): `01acaa60` -> `a994d570`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -74,11 +74,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1784796856,
-        "narHash": "sha256-wWFrV5/Qbm+lyt5x20E/bSbfJiGKMo4RCxZV8cl/WZI=",
+        "lastModified": 1785967620,
+        "narHash": "sha256-IItrdb7Puk05RqOBWZYFC5X6Wl1sJmCfh5MWVHw5iMM=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e2587caef70cea85dd97d7daab492899902dbf5d",
+        "rev": "b7c2ada94fe99c15b0dbcf4d11fd7850b957a436",
         "type": "github"
       },
       "original": {
@@ -112,11 +112,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1785487287,
-        "narHash": "sha256-3eF2bngygCD5mfzUKbXWYFXRSCmHcPnEiHZdbeyGc4k=",
+        "lastModified": 1786105217,
+        "narHash": "sha256-ySp0dc1E9ZorICTvG1467QKzZYCp0fcBECEeycz3Dtw=",
         "owner": "FredSystems",
         "repo": "pre-commit-checks",
-        "rev": "01acaa60808b41153970f9b0985ffb142b2ebfe5",
+        "rev": "a994d570247f1d80cbbcd8a33c4b4f866e16af87",
         "type": "github"
       },
       "original": {
@@ -136,11 +136,11 @@
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1785476452,
-        "narHash": "sha256-/CXwCFPS41rb/JI2VitKCgVK6V5E6/sfw5ke3B9zyVQ=",
+        "lastModified": 1786076960,
+        "narHash": "sha256-jfR6OhwurCKn1tREyfOcK/Omxf1Q/DzDDFbnEr1mBLs=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "6ef009bf4c4873cdc1a621826722bdea7c03e62c",
+        "rev": "57a23bfaf4f7017267294b161175db1e32eb1c85",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                         | Message                                               |
| -------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
| [`a994d570`](https://github.com/fredsystems/pre-commit-checks/commit/a994d570247f1d80cbbcd8a33c4b4f866e16af87) | `` chore(flake/nixpkgs): 64380905 -> b7c2ada9 ``      |
| [`6d588ead`](https://github.com/fredsystems/pre-commit-checks/commit/6d588ead20bf977d4cc6fd499b8760e6f3ccd281) | `` chore(flake/rust-overlay): 29224977 -> 57a23bfa `` |
| [`01cf5823`](https://github.com/fredsystems/pre-commit-checks/commit/01cf5823724a9482eb716739e106354e62b14e01) | `` chore(flake/nixpkgs): e2587cae -> 64380905 ``      |
| [`73eaf96e`](https://github.com/fredsystems/pre-commit-checks/commit/73eaf96e4e293056878278c94ee6063362b282d9) | `` chore(flake/rust-overlay): 6ef009bf -> 29224977 `` |
| [`e9cf4ecf`](https://github.com/fredsystems/pre-commit-checks/commit/e9cf4ecff1f40ae5af7ef49d0db56699ba1a5b9e) | `` switch to tscgo ``                                 |
| [`0bd7d9c7`](https://github.com/fredsystems/pre-commit-checks/commit/0bd7d9c7cec4f68d8ef134ec48be0bac98f4c5fd) | `` switch to tscgo ``                                 |
| [`e211dcc4`](https://github.com/fredsystems/pre-commit-checks/commit/e211dcc41ca3e096a87df068c701423e5c1e5ab3) | `` switch to tscgo ``                                 |
| [`b89aae04`](https://github.com/fredsystems/pre-commit-checks/commit/b89aae04fa1bab38b15b5a2023571eb751cc9e85) | `` switch to tscgo ``                                 |
| [`35e756c3`](https://github.com/fredsystems/pre-commit-checks/commit/35e756c3e429fc8243706b640fc5d3b906e65d04) | `` switch to tscgo ``                                 |